### PR TITLE
Use default GraphicsEnvironment instead of Toolkit to determine screen bounds

### DIFF
--- a/src/main/java/tdl/record/screen/image/input/InputFromScreen.java
+++ b/src/main/java/tdl/record/screen/image/input/InputFromScreen.java
@@ -20,9 +20,11 @@ public class InputFromScreen implements ImageInput {
         try {
             //OBS: Robot requires AWTPermission, it might be wise to use a policy file, see http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html
             //OBS: Robot starts an app called AppMain. What is the deal with it ?
-            Toolkit defaultToolkit = Toolkit.getDefaultToolkit();
             this.robot = new Robot();
-            this.screenBounds = new Rectangle(defaultToolkit.getScreenSize());
+            this.screenBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                                                   .getDefaultScreenDevice()
+                                                   .getDefaultConfiguration()
+                                                   .getBounds();
         } catch (AWTException e) {
             throw new InputImageGenerationException(e);
         }


### PR DESCRIPTION
Fixes [#3](https://github.com/julianghionoiu/dev-screen-record/issues/3)

I do not know how to test it though. There are no unit tests for this class (only a "manual acceptance test", but this one is [not implemented](https://github.com/julianghionoiu/dev-screen-record/blob/8d5761d1aaefdc3513e263dcbe3689b8a3b4949b/src/test/java/acceptance/CanRecordVideoTest.java#L58)).